### PR TITLE
delete torch.nn.functional

### DIFF
--- a/labml_nn/diffusion/stable_diffusion/latent_diffusion.py
+++ b/labml_nn/diffusion/stable_diffusion/latent_diffusion.py
@@ -25,7 +25,6 @@ from typing import List
 
 import torch
 import torch.nn as nn
-import torch.nn.functional
 
 from labml_nn.diffusion.stable_diffusion.model.autoencoder import Autoencoder
 from labml_nn.diffusion.stable_diffusion.model.clip_embedder import CLIPTextEmbedder

--- a/labml_nn/diffusion/stable_diffusion/model/unet.py
+++ b/labml_nn/diffusion/stable_diffusion/model/unet.py
@@ -20,7 +20,6 @@ from typing import List
 
 import numpy as np
 import torch
-import torch as th
 import torch.nn as nn
 import torch.nn.functional as F
 
@@ -174,7 +173,7 @@ class UNetModel(nn.Module):
         x = self.middle_block(x, t_emb, cond)
         # Output half of the U-Net
         for module in self.output_blocks:
-            x = th.cat([x, x_input_block.pop()], dim=1)
+            x = torch.cat([x, x_input_block.pop()], dim=1)
             x = module(x, t_emb, cond)
 
         # Final normalization and $3 \times 3$ convolution


### PR DESCRIPTION
I find useless import in [Latent diffusion model](https://nn.labml.ai/diffusion/stable_diffusion/latent_diffusion.html)
Therefore, I delete **import torch.nn.functional**.

Before :
```python
import torch
import torch.nn as nn
import torch.nn.functional
```

After :
```python
import torch
import torch.nn as nn
```
<hr>
Additionally, I find more unnecessary import in the unet.py. I delete and replace code. 

```python
import torch
import torch as th #This code have used one time. 
x = th.cat([x, x_input_block.pop()], dim=1)
```
```python
x = torch.cat([x, x_input_block.pop()], dim=1) #Therefore, I delete the code, and replcae th.cat -> torch.cat.
```