### PR TITLE
Add the missing negative sign in the formula.

### DIFF
--- a/labml_nn/transformers/rope/__init__.py
+++ b/labml_nn/transformers/rope/__init__.py
@@ -137,7 +137,7 @@ class RotaryPositionalEmbeddings(nn.Module):
         # Get sequence length
         seq_len = x.shape[0]
 
-        # $\Theta = {\theta_i = 10000^{\frac{2(i-1)}{d}}, i \in [1, 2, ..., \frac{d}{2}]}$
+        # $\Theta = {\theta_i = 10000^{-\frac{2(i-1)}{d}}, i \in [1, 2, ..., \frac{d}{2}]}$
         theta = 1. / (self.base ** (torch.arange(0, self.d, 2).float() / self.d)).to(x.device)
 
         # Create position indexes `[0, 1, ..., seq_len - 1]`


### PR DESCRIPTION
In the following code, the formula in the comments is not consistent with the code as a negative sign has been omitted in the comments.

https://github.com/labmlai/annotated_deep_learning_paper_implementations/blob/df566e0d48e7025bba50d82269f687839d182b35/labml_nn/transformers/rope/__init__.py#L140-L141