### PR TITLE
fix: fix cls_token bug in vit.

### DIFF
--- a/labml_nn/transformers/vit/__init__.py
+++ b/labml_nn/transformers/vit/__init__.py
@@ -191,11 +191,11 @@ class VisionTransformer(Module):
         """
         # Get patch embeddings. This gives a tensor of shape `[patches, batch_size, d_model]`
         x = self.patch_emb(x)
-        # Add positional embeddings
-        x = self.pos_emb(x)
         # Concatenate the `[CLS]` token embeddings before feeding the transformer
         cls_token_emb = self.cls_token_emb.expand(-1, x.shape[1], -1)
         x = torch.cat([cls_token_emb, x])
+        # Add positional embeddings
+        x = self.pos_emb(x)
 
         # Pass through transformer layers with no attention masking
         for layer in self.transformer_layers:


### PR DESCRIPTION
![截图 2023-11-06 11-36-55](https://github.com/labmlai/annotated_deep_learning_paper_implementations/assets/100779955/14b92bba-314c-412c-8c56-694d464df4c3)
The original text also requires position embedding for the `cls_token_emb`. Therefore, you should first concatenate the `cls_token_emb` with `x` and assign it to `x`, and then perform the position embedding operation on `x`.