### PR TITLE
Add backticks to mask'shape

### DIFF
--- a/labml_nn/transformers/alibi/__init__.py
+++ b/labml_nn/transformers/alibi/__init__.py
@@ -158,7 +158,7 @@ class AlibiMultiHeadAttention(MultiHeadAttention):
 
         # Create AliBi biases if it's not cached
         if self.alibi_biases is None or self.alibi_biases.shape[1] < seq_len:
-            # `mask` has shape [seq_len, seq_len, 1, 1]
+            # `mask` has shape `[seq_len, seq_len, 1, 1]`
             self.alibi_biases = get_alibi_biases(scores.shape[-1], mask[:, :, 0, 0])
 
         # Add AliBi biases to attention scores.


### PR DESCRIPTION
https://nn.labml.ai/transformers/alibi/index.html#section-24
the `mask`'shape on this line is the index of the jump due to not adding backticks.