### PR TITLE
Fix a typo in the formula of ALiBi.

### DIFF
--- a/labml_nn/transformers/alibi/__init__.py
+++ b/labml_nn/transformers/alibi/__init__.py
@@ -19,7 +19,7 @@ Here's the attention formula for $i$-th token,
 
 \begin{align}
 \mathbf{a}_i
-&= \text{softmax} \bigg( \mathbf{q}_i \mathbf{K}^\top + m \cdot \big[-(i-1), \dots, 1, 0 \big] \bigg) \\
+&= \text{softmax} \bigg( \mathbf{q}_i \mathbf{K}^\top + m \cdot \big[-(i-1), \dots, -1, 0 \big] \bigg) \\
 &= \text{softmax} \bigg( \mathbf{q}_i \mathbf{K}^\top + m \cdot \big[0, 1, \dots, (i - 1) \big] \bigg)
 \end{align}
 


### PR DESCRIPTION
This formula is wrong, there is one symbol '-' missing in front of the 1, which will affect people's understanding when reading. What is expressed here is that the position of the ith token is increasing from -(i-1) to 0, so it should be -1.