### PR TITLE
Fix a typo in the formula of RoPE

### DIFF
--- a/labml_nn/transformers/rope/__init__.py
+++ b/labml_nn/transformers/rope/__init__.py
@@ -78,7 +78,7 @@ class RotaryPositionalEmbeddings(nn.Module):
     x^{(1)}_m x^{(1)}_n \cos (m - n) \theta +
     x^{(1)}_m x^{(2)}_n \sin(m - n) \theta &+ \\
     - x^{(2)}_m x^{(1)}_n \sin (m - n) \theta +
-    x^{(2)}_m x^{(1)}_n \cos (m - n) \theta &= \\
+    x^{(2)}_m x^{(2)}_n \cos (m - n) \theta &= \\
 
     \big(x^{(1)}_m \cos (m - n)\theta - x^{(2)}_m \sin (m - n) \theta\big) x^{(1)}_n &+ \\
     \big(x^{(2)}_m \cos (m - n)m\theta + x^{(1)}_m \sin (m - n) \theta\big) x^{(2)}_n  &= \\


### PR DESCRIPTION
There is `x^{(1)}_n` instead of `x^{(2)}_n` in one line of the formula:

76 : `x^{(2)}_m x^{(2)}_n (\sin m\theta \sin n\theta + \cos m \theta \cos n \theta)`
become 
81 : `x^{(2)}_m x^{(1)}_n \cos (m - n) \theta`
