### PR TITLE
fix model error

### DIFF
--- a/labml_nn/transformers/rope/__init__.py
+++ b/labml_nn/transformers/rope/__init__.py
@@ -185,7 +185,7 @@ class RotaryPositionalEmbeddings(nn.Module):
         # \end{align}
         #
         # for $i \in {1, 2, ..., \frac{d}{2}}$
-        x_rope = (x_rope * self.cos_cached[:x.shape[0]]) + (neg_half_x * self.sin_cached[:x.shape[0]])
+        x_rope = (x_rope * self.cos_cached[...,:x.shape[0]]) + (neg_half_x * self.sin_cached[...,:x.shape[0]])
 
         #
         return torch.cat((x_rope, x_pass), dim=-1)


### PR DESCRIPTION
fix the following error:
```
Traceback (most recent call last):
  File "e:\data\frid\python\codes\adlpi\labml_nn\transformers\rope\__init__.py", line 231, in <module>
    _test_rotary()
  File "e:\data\frid\python\codes\adlpi\labml_nn\transformers\rope\__init__.py", line 227, in _test_rotary
    inspect(rotary_pe(x))
  File "E:\data\frid\python\p121\lib\site-packages\torch\nn\modules\module.py", line 1518, in _wrapped_call_impl
  File "e:\data\frid\python\codes\adlpi\labml_nn\transformers\rope\__init__.py", line 188, in forward
    x_rope = (x_rope * self.cos_cached[:x.shape[0]]) + (neg_half_x * self.sin_cached[:x.shape[0]])
RuntimeError: The size of tensor a (3) must match the size of tensor b (4) at non-singleton dimension 3
```
the reason is that the dimensions of two multiplied vectors do not match.