### PR TITLE
fix dim error in rope

### DIFF
--- a/labml_nn/transformers/rope/__init__.py
+++ b/labml_nn/transformers/rope/__init__.py
@@ -185,7 +185,7 @@ class RotaryPositionalEmbeddings(nn.Module):
         # \end{align}
         #
         # for $i \in {1, 2, ..., \frac{d}{2}}$
-        x_rope = (x_rope * self.cos_cached[:x.shape[0]]) + (neg_half_x * self.sin_cached[:x.shape[0]])
+        x_rope = (x_rope * self.cos_cached[: x.shape[0], ..., : self.d]) + (neg_half_x * self.sin_cached[: x.shape[0], ..., : self.d])
 
         #
         return torch.cat((x_rope, x_pass), dim=-1)


### PR DESCRIPTION
fix the following error when running _test_rotary():

"""
...
    x_rope = (x_rope * self.cos_cached[:x.shape[0]]) + (neg_half_x * self.sin_cached[:x.shape[0]])
RuntimeError: The size of tensor a (3) must match the size of tensor b (4) at non-singleton dimension 3
"""