### PR TITLE
Fix docstring typo in nucleus sampling

### DIFF
--- a/labml_nn/sampling/nucleus.py
+++ b/labml_nn/sampling/nucleus.py
@@ -19,7 +19,7 @@ where $V^{(p)}$ is smallest set of tokens such that
 
 $$\sum_{x_i \in V^{(p)}} P(x_i | x_{1:i-1}) \ge p$$
 
-That is, we pick the highest probable tokens until the sum of their probabilities is less that $p$.
+That is, we pick the highest probable tokens until the sum of their probabilities is at least $p$.
 
 Then we sample from the selected tokens.
 
@@ -61,7 +61,7 @@ class NucleusSampler(Sampler):
         # Find the cumulative sums less than $p$.
         nucleus = cum_sum_probs < self.p
         # Prepend ones so that we add one token after the minimum number
-        # of tokens with cumulative probability less that $p$.
+        # of tokens with cumulative probability less than $p$.
         nucleus = torch.cat([nucleus.new_ones(nucleus.shape[:-1] + (1,)), nucleus[..., :-1]], dim=-1)
 
         # Get log probabilities and mask out the non-nucleus


### PR DESCRIPTION
## Summary
- Fixes #293
- Fixed "is less that $p$" to "is at least $p$" in the module docstring (line 22) — corrects both the typo ("that" -> "than") and the semantics ("less than" -> "at least"), since nucleus sampling selects the smallest set of tokens whose cumulative probability **meets or exceeds** p
- Fixed "less that" to "less than" in an inline comment (line 64) — typo-only fix, semantics were correct there

## Test plan
- [x] Verified the fix matches the formula already present in the docstring: $\sum_{x_i \in V^{(p)}} P(x_i | x_{1:i-1}) \ge p$

🤖 Generated with [Claude Code](https://claude.com/claude-code)